### PR TITLE
Added the options passwordHint and userNameHint

### DIFF
--- a/ui/dialogs/dialogs.android.ts
+++ b/ui/dialogs/dialogs.android.ts
@@ -176,10 +176,12 @@ export function login(arg: any): Promise<dialogs.LoginResult> {
 
             var userNameInput = new android.widget.EditText(context);
             userNameInput.setText(options.userName ? options.userName : "");
+            userNameInput.setHint(options.userNameHint ? options.userNameHint : "");
 
             var passwordInput = new android.widget.EditText(context);
             passwordInput.setInputType(android.text.InputType.TYPE_CLASS_TEXT | android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD);
             passwordInput.setText(options.password ? options.password : "");
+            passwordInput.setHint(options.passwordHint ? options.passwordHint : "");
 
             var layout = new android.widget.LinearLayout(context);
             layout.setOrientation(1);


### PR DESCRIPTION
I've discovered that the options password and userName in the Login Dialog, set the defaults values for this fields.

I've added this two options to help the user to understand what the fields mean
